### PR TITLE
Fixes for AJAX-loaded fields

### DIFF
--- a/SelectizeImageTags.js
+++ b/SelectizeImageTags.js
@@ -3,21 +3,27 @@
  * ============================================
  */
 
-function lookup(array, prop, value) {
-    for (var i = 0, len = array.length; i < len; i++)
-        if (array[i] && array[i][prop] === value) return array[i];
-}
-
-$(document).ready(function () {
+function initSelectizeImageTags() {
 
     for(var name in config.SelectizeImageTags) {
+
+        // get inputfields
+        var thisTagsFields = $("." + name);
+        // get inputfields inside repeaters
+        var thisRepeaterTagsFields = $("li[class*='" + name + "_repeater']").filter(function() {
+            var re = new RegExp("\\b" + name + "_repeater");
+            return this.className.match(re);
+        });
+        // get the inputs inside those inputfields
+        var thisTagsInputs = thisTagsFields.add(thisRepeaterTagsFields).find("input[name^='tags_']");
+
         // at this point, name is our fieldName, and field holds the selectize init object
         var field = config.SelectizeImageTags[name];
 
         if(field.create == true) {
+
             // each image has it's own tags field...
-            thisTagsFields = $("." + name + " input[name^='tags_']");
-            thisTagsFields.each(function() {
+            thisTagsInputs.each(function() {
 
                 var thisTagsField = $(this);
                 var thisTags = thisTagsField.val();
@@ -34,10 +40,27 @@ $(document).ready(function () {
 
         } // end if value.create
 
-        $("." + name + " input[name^='tags_']").selectize(field);
+        thisTagsInputs.selectize(field);
 
     }
+}
 
+function lookup(array, prop, value) {
+    for (var i = 0, len = array.length; i < len; i++)
+        if (array[i] && array[i][prop] === value) return array[i];
+}
+
+// Init on DOM ready
+$(document).ready(function () {
+    initSelectizeImageTags();
 });
 
+// Init on AJAX-loading of image field
+$(document).on('reloaded', '.InputfieldImage', function() {
+    initSelectizeImageTags();
+});
 
+// Init on image uploaded
+$(document).on('AjaxUploadDone', '.gridImages', function() {
+    initSelectizeImageTags();
+});

--- a/SelectizeImageTags.module
+++ b/SelectizeImageTags.module
@@ -22,7 +22,7 @@ class SelectizeImageTags extends WireData implements Module {
             'autoload' => 'template=admin',
             'requires'  => array(
                 'JquerySelectize',
-                'ProcessWire>=3.0.67'
+                'ProcessWire>=3.0.61'
             )
         );
     }
@@ -33,7 +33,7 @@ class SelectizeImageTags extends WireData implements Module {
 	public function ___upgrade($fromVersion, $toVersion) {
 		// Upgrade from < v0.0.3
 		if($fromVersion < 3) {
-			if($this->config->version < '3.0.67') {
+			if($this->config->version < '3.0.61') {
 				throw new WireException("The minimum required ProcessWire version is 3.0.61");
 			}
 		}

--- a/SelectizeImageTags.module
+++ b/SelectizeImageTags.module
@@ -27,6 +27,18 @@ class SelectizeImageTags extends WireData implements Module {
         );
     }
 
+	/**
+	 * Upgrade
+	 */
+	public function ___upgrade($fromVersion, $toVersion) {
+		// Upgrade from < v0.0.3
+		if($fromVersion < 3) {
+			if($this->config->version < '3.0.67') {
+				throw new WireException("The minimum required ProcessWire version is 3.0.61");
+			}
+		}
+	}
+
     protected $jsConfig = array();
 
     public function addProperty(HookEvent $event) {

--- a/SelectizeImageTags.module
+++ b/SelectizeImageTags.module
@@ -14,13 +14,16 @@ class SelectizeImageTags extends WireData implements Module {
         return array(
             'title' => 'Selectize Image Tags',
             'author' => 'Macrura',
-            'version' => 002,
+            'version' => 003,
             'summary' => 'Admin helper for enabling selectize.js on images tags field.',
             'href' => '',
             'icon' => 'tags',
             'singular' => true,
             'autoload' => 'template=admin',
-            'requires'  => array("JquerySelectize")
+            'requires'  => array(
+                'JquerySelectize',
+                'ProcessWire>=3.0.61'
+            )
         );
     }
 
@@ -87,7 +90,7 @@ class SelectizeImageTags extends WireData implements Module {
             $field->showIf = 'selectizeTagField>0';
             $field->value = isset($that->selectizePlugins) ? $that->selectizePlugins : '';
             $field->columnWidth = 50;
-            $event->return->append($field); 
+            $event->return->append($field);
 
         });
 
@@ -104,7 +107,7 @@ class SelectizeImageTags extends WireData implements Module {
          * uses this field/module and add the attrs to the fields.
          *
          */
-        $this->addHookBefore('InputfieldImage::render', function($event) {
+        $this->addHookBefore('InputfieldImage::renderReadyHook', function($event) {
 
             $that = $event->object;
 
@@ -126,7 +129,7 @@ class SelectizeImageTags extends WireData implements Module {
                     $tagsArray = array();
 
                     // User strings
-                    $selectizeTagList = explode(PHP_EOL, $that->selectizeTagList);
+                    $selectizeTagList = explode("\n", $that->selectizeTagList);
                     foreach($selectizeTagList as $row) {
                         $parts = explode(',', $row);
                         $tagVal = trim($parts[0]);

--- a/SelectizeImageTags.module
+++ b/SelectizeImageTags.module
@@ -22,7 +22,7 @@ class SelectizeImageTags extends WireData implements Module {
             'autoload' => 'template=admin',
             'requires'  => array(
                 'JquerySelectize',
-                'ProcessWire>=3.0.61'
+                'ProcessWire>=3.0.67'
             )
         );
     }


### PR DESCRIPTION
Hooks "renderReadyHook" instead of "render" so that JS config is
populated for AJAX-loaded fields. As a consequence, minimum required PW
version is now 3.0.61.
Moves JS initialisation to a function. Function is called when image
field is 'reloaded' (fix for AJAX-loaded fields) and when images are
uploaded (fix for new uploads) as well as DOM ready.
JS checks for modified inputfield name when rendered inside a repeater
item.
Also fix for newline character in tags config field.